### PR TITLE
Bugfix: Match Multiple paths.

### DIFF
--- a/giturlparse/parser.py
+++ b/giturlparse/parser.py
@@ -41,7 +41,7 @@ POSSIBLE_REGEXES = (
                r'(?P<resource>[a-z0-9_.-]*)'
                r'[:/]*'
                r'(?P<port>[\d]+){0,1}'
-               r'(?P<pathname>\/((?P<owner>[\w\-]+)\/)?'
+               r'(?P<pathname>\/((?P<owner>[\w\-\/]+)\/)?'
                r'((?P<name>[\w\-\.]+?)(\.git)?)?)$'),
     re.compile(r'(git\+)?'
                r'((?P<protocol>\w+)://)'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -260,6 +260,17 @@ def first_match_urls():
             'name': 'Stouts.openvpn',
             'owner': 'tterranigma',
         },
+        'https://github.com/Group/Owner/Stouts.openvpn.git': {
+            'pathname': '/Group/Owner/Stouts.openvpn.git',
+            'protocols': ['https'],
+            'protocol': 'https',
+            'href': 'https://github.com/Group/Owner/Stouts.openvpn.git',
+            'resource': 'github.com',
+            'user': None,
+            'port': None,
+            'name': 'Stouts.openvpn',
+            'owner': 'Group/Owner'
+        }
     }
 
 


### PR DESCRIPTION
Since GitLab has `Group` and `SubGroup` concept, and repo can be under SubGroup, so the repo URL can be `https://gitlab.example.com/group/sub-group/example.git`.