### PR TITLE
Feature: Add GitLab groups repo support.

### DIFF
--- a/giturlparse/parser.py
+++ b/giturlparse/parser.py
@@ -43,6 +43,13 @@ POSSIBLE_REGEXES = (
                r'(?P<port>[\d]+){0,1}'
                r'(?P<pathname>\/((?P<owner>[\w\-]+)\/)?'
                r'((?P<name>[\w\-\.]+?)(\.git|\/)?)?)$'),
+    re.compile(r'^(?P<protocol>https?|git|ssh|rsync)\://'
+               r'(?:(?P<user>.+)@)*'
+               r'(?P<resource>[a-z0-9_.-]*)'
+               r'[:/]*'
+               r'(?P<port>[\d]+){0,1}'
+               r'(?P<pathname>\/((?P<owner>[\w\-\/]+)\/)?'
+               r'((?P<name>[\w\-\.]+?)(\.git)?)?)$'),
     re.compile(r'(git\+)?'
                r'((?P<protocol>\w+)://)'
                r'((?P<user>\w+)@)?'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -315,6 +315,17 @@ def first_match_urls():
             'name': 'Stouts.openvpn',
             'owner': 'tterranigma',
         },
+        'https://gitlab.com/Group/Owner/repo.git': {
+            'pathname': '/Group/Owner/repo.git',
+            'protocols': ['https'],
+            'protocol': 'https',
+            'href': 'https://gitlab.com/Group/Owner/repo.git',
+            'resource': 'gitlab.com',
+            'user': None,
+            'port': None,
+            'name': 'repo',
+            'owner': 'Group/Owner'
+        },
     }
 
 


### PR DESCRIPTION
Since GitLab has Group and SubGroup concept, and repo can be under SubGroup, so the repo URL can be like this: https://gitlab.example.com/group/sub-group/example.git.

Thanks to @jayvdb suggestion and I have made the changes of my previous PR.